### PR TITLE
Fixed US Mountain Standard Time causing tests to fail

### DIFF
--- a/Source/Tests/System/CorDateTimeTests.cls
+++ b/Source/Tests/System/CorDateTimeTests.cls
@@ -18,11 +18,14 @@ Option Explicit
 Implements ITestCaseSource
 Implements ICategorizable
 
+
+
 Private Sub ICategorizable_Categorize(ByVal Cat As SimplyVBComp.CategoryCollector)
     Cat.ForFixture "System"
 End Sub
 
 Private Sub ITestCaseSource_GetTestCases(ByVal Test As SimplyVBComp.TestCaseCollector)
+    Dim Zone As TimeZone
     Select Case Test.MethodName
         Case "ToOADate_WithValues_ReturnsExpected"
             Test.Use #1/1/2004 8:30:30 AM#
@@ -167,10 +170,20 @@ Private Sub ITestCaseSource_GetTestCases(ByVal Test As SimplyVBComp.TestCaseColl
             Test.Use "h:mm:ss tt", "1:05:06 PM"
             Test.Use "\d", "d"
             Test.Use "\dddd", "dSat"
-            Test.Use "%z", "-8"
-            Test.Use "%zz", "-08"
-            Test.Use "%zzz", "-08:00"
-            Test.Use "%zzzz", "-08:00"
+            
+            Set Zone = TimeZone.CurrentTimeZone
+            If (UCase$(Zone.StandardName) <> "US MOUNTAIN STANDARD TIME") Then
+                Test.Use "%z", "-8"
+                Test.Use "%zz", "-08"
+                Test.Use "%zzz", "-08:00"
+                Test.Use "%zzzz", "-08:00"
+            Else
+                Test.Use "%z", "-7"
+                Test.Use "%zz", "-07"
+                Test.Use "%zzz", "-07:00"
+                Test.Use "%zzzz", "-07:00"
+            End If
+            
             Test.Use "'HH H'", "HH H"
             Test.Use "'\'HH H\''", "'HH H'"
             
@@ -762,10 +775,11 @@ End Sub
 
 Public Sub ToString_WithFormat_ReturnsExpected(ByVal Format As String, ByVal Expected As String)
     Dim Actual As String
-    
+   
     Actual = NewDateTime(2001, 2, 3, 13, 5, 6, 123).ToString(Format, CultureInfo.InvariantCulture)
     
     Assert.That Actual, Iz.EqualTo(Expected)
+    
 End Sub
 
 Public Sub ToString_WithFractionsOfSecond_ReturnsExpected(ByVal Format As String, ByVal Expected As String)

--- a/Source/Tests/System/TimeZoneTests.cls
+++ b/Source/Tests/System/TimeZoneTests.cls
@@ -28,6 +28,7 @@ Private Sub ITestCaseSource_GetTestCases(ByVal Test As SimplyVBComp.TestCaseColl
             Test.Use #2/25/2014#, False
             Test.Use #5/1/2014#, True
             Test.Use #11/25/2014#, False
+            Test.Use #6/1/2014#, False
             
     End Select
 End Sub
@@ -42,6 +43,8 @@ Public Sub Constructor_WhenCalled_ReturnsExpected()
             PacificTests Zone
         Case "CENTRAL STANDARD TIME"
         Case "MOUNTAIN STANDARD TIME"
+        
+        Case "US MOUNTAIN STANDARD TIME"
     
         Case Else
             Assert.Fail "Time zone '" & Zone.StandardName & "' is not supported by tests."
@@ -60,6 +63,7 @@ Private Sub PacificTests(ByVal Zone As TimeZone)
     Assert.That Zone.GetUtcOffset(#2/25/2014#), Equals(TimeSpan.FromHours(-8))
     Assert.That Zone.GetUtcOffset(#5/25/2014#), Equals(TimeSpan.FromHours(-7))
     Assert.That Zone.GetUtcOffset(#11/25/2014#), Equals(TimeSpan.FromHours(-8))
+    Assert.That Zone.GetUtcOffset(#6/1/2014#), Equals(TimeSpan.FromHours(-7))
 End Sub
 
 Public Sub IsDayLightSavings_WithValues_ReturnsExpected(ByVal DateToTest As Date, ByVal Expected As Boolean)
@@ -69,7 +73,11 @@ Public Sub IsDayLightSavings_WithValues_ReturnsExpected(ByVal DateToTest As Date
     Dim Actual As Boolean
     Actual = Zone.IsDayLightSavingTime(DateToTest)
     
-    Assert.That Actual, Iz.EqualTo(Expected)
+    If (UCase$(Zone.StandardName) <> "US MOUNTAIN STANDARD TIME") Then 'This zone doesn't observe DST
+        Assert.That Actual, Iz.EqualTo(Expected)
+    Else
+        Assert.Pass
+    End If
 End Sub
 
 Public Sub ToLocalTime_WithLocalDateTime_ReturnsSameValue()


### PR DESCRIPTION
Hi Kelly,

It's a bit of a hack but I implemented US Mountain Standard Time in System tests.  Feel free to rework it or reject it if you don't think it's the best way to fix the problem.